### PR TITLE
Validate keys in GPT response

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ OPENAI_API_KEY=YOUR_KEY_HERE
 Then run the CLI:
 
 ```bash
-python cli.py
+python cli.py [--auto-send]
 ```
+
+Use `--auto-send` to send replies automatically without manual confirmation.
 
 The script checks your unread emails, uses GPT to decide if a response is needed and, when appropriate, drafts a reply for you to send.


### PR DESCRIPTION
## Summary
- ensure the GPT response contains `should_reply` and `draft_reply`
- add `--auto-send` option to skip confirmation before sending replies

## Testing
- `python -m py_compile cli.py`
