### PR TITLE
Improve spam detection and language matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ python cli.py [--auto-send]
 Use `--auto-send` to send replies automatically without manual confirmation.
 
 The script checks your unread emails, uses GPT to decide if a response is needed and, when appropriate, drafts a reply for you to send.
+Replies are written in the same language as the incoming email. Messages that are detected as spam or marketing are automatically reported to Gmail instead of just being marked read.


### PR DESCRIPTION
## Summary
- tighten GPT instructions to reject marketing emails and identify spam
- ensure replies use the same language as the original message
- report spam messages to Gmail instead of merely marking them read
- document new behaviour in README

## Testing
- `python -m py_compile cli.py`